### PR TITLE
Cancell installing latest npm

### DIFF
--- a/build/rpmbuild-docker/Dockerfile
+++ b/build/rpmbuild-docker/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf module enable -y nodejs:18
 RUN yum -y --allowerasing install nodejs yum-utils rpmdevtools createrepo_c mock git golang \
         jq make gcc-c++ rsync rkhunter coreutils
 
-RUN npm uninstall -g yarn pnpm && npm install -g npm@latest corepack
+RUN npm uninstall -g yarn pnpm && npm install -g corepack
 
 RUN useradd builder -u 1000 -m -G users,wheel,mock && \
     chmod 755 /home/builder


### PR DESCRIPTION
Currently we install the latest npm in the rpm build image, this could be problematic because the latest npm may require higher version of nodejs than the one in the RPEL repo, as shown in the below error logs, we should probably stay with the version that comes with the nodejs package.

```
[+] Building 2.7s (11/33)                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                          0.0s
 => => transferring dockerfile: 2.31kB                                                                                        0.0s
 => [internal] load .dockerignore                                                                                             0.1s
 => => transferring context: 2B                                                                                               0.0s
 => [internal] load metadata for docker.io/library/rockylinux:9.2-minimal                                                     0.2s
 => [auth] library/rockylinux:pull token for registry-1.docker.io                                                             0.0s
 => [ 1/28] FROM docker.io/library/rockylinux:9.2-minimal@sha256:594c839a772e23ee354d2f05acbb5779665d48aed742375aae174971786  0.0s
 => [internal] load build context                                                                                             0.2s
 => => transferring context: 241.32kB                                                                                         0.2s
 => CACHED [ 2/28] RUN microdnf -y update &&     microdnf -y install yum                                                      0.0s
 => CACHED [ 3/28] RUN yum -y install epel-release                                                                            0.0s
 => CACHED [ 4/28] RUN dnf module enable -y nodejs:18                                                                         0.0s
 => CACHED [ 5/28] RUN yum -y --allowerasing install nodejs yum-utils rpmdevtools createrepo_c mock git golang         jq ma  0.0s
 => ERROR [ 6/28] RUN npm uninstall -g yarn pnpm && npm install -g npm@latest corepack                                        2.3s
------
 > [ 6/28] RUN npm uninstall -g yarn pnpm && npm install -g npm@latest corepack:
1.542
1.542 up to date in 157ms
2.168 npm ERR! code EBADENGINE
2.169 npm ERR! engine Unsupported engine
2.170 npm ERR! engine Not compatible with your version of node/npm: npm@10.1.0
2.170 npm ERR! notsup Not compatible with your version of node/npm: npm@10.1.0
2.171 npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
2.171 npm ERR! notsup Actual:   {"npm":"9.5.1","node":"v18.16.1"}
2.172
2.173 npm ERR! A complete log of this run can be found in:
2.173 npm ERR!     /root/.npm/_logs/2023-09-25T05_30_07_635Z-debug-0.log
------
Dockerfile:10
--------------------
   8 |             jq make gcc-c++ rsync rkhunter coreutils
   9 |
  10 | >>> RUN npm uninstall -g yarn pnpm && npm install -g npm@latest corepack
  11 |
  12 |     RUN useradd builder -u 1000 -m -G users,wheel,mock && \
--------------------
ERROR: failed to solve: process "/bin/sh -c npm uninstall -g yarn pnpm && npm install -g npm@latest corepack" did not complete successfully: exit code: 1
```