### PR TITLE
Add build records to avoid redundant rebuilding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/
 .kitchen/
 build/bin/runenv
 build/debbuild-docker/dep/
+build/records/**

--- a/build/bin/build-deb
+++ b/build/bin/build-deb
@@ -30,6 +30,28 @@ build_deb() {
         exit 1
     fi
 
+    built_filepaths="$(echo "${deb_records[${package}]}" | cut -d',' -f1)"
+    built_revision="$(echo "${deb_records[${package}]}" | cut -d',' -f2)"
+    cd "${submodule_dir}/${package}"
+    current_revision="$(git rev-parse --short  HEAD)"
+    [ ! -z "$current_revision" ] || fatal "${package} : Can't not get git commit id of ${package}"
+
+    all_exist=0
+    for path in ${built_filepaths//:/ }
+    do
+        all_exist=1
+        if [ ! -f "$path" ]
+        then
+            all_exist=0
+            break
+        fi
+    done
+    if [ "$built_revision" = "$current_revision" ] && [ "$all_exist" -gt "0" ]
+    then
+        echo "${package}: RPM of revision '$current_revision' already built, skipped."
+        return
+    fi
+
     if ! compgen -G  "${sdeb_dir}/${package}_${version}*.dsc" > /dev/null; then
         echo "sdeb files not exist"
         exit 1
@@ -47,11 +69,27 @@ build_deb() {
         popd
 
         mkdir -p ${deb_dir}
+        rm -rf ${sdeb_dir}/${package}*
         mv ${tmp_dir}/debbuild/DEB/${package}_${version}*.deb ${deb_dir}
         mv ${tmp_dir}/debbuild/DEB/${package}_${version}*.changes ${deb_dir}
     popd
 
     rm -rf ${tmp_dir}/debbuild/DEB/${package}*
+    printf -v deb_filepaths '%s:' $(ls ${deb_dir}/${package}*)
+    deb_records[$package]="${deb_filepaths%%:},${current_revision}"
+
+    record_content=
+    for k in "${!deb_records[@]}"
+    do
+        if [ -z "${record_content}" ]
+		then
+			record_content="${k},${deb_records[${k}]}"
+		else
+			record_content="${record_content}"$'\n'"${k},${deb_records[${k}]}"
+		fi
+    done
+    mkdir -p "${record_dir}"
+    echo "$record_content" > "${deb_record_file}"
 }
 
 main() {

--- a/build/bin/build-rpm
+++ b/build/bin/build-rpm
@@ -23,38 +23,75 @@ EOF
 
 build_rpm() {
     local package=$1
-    local version=${2##v}
+    local srpm_filepath="$2"
+    local result_dir=${3:-"${tmp_dir}/mock/${package}"}
     local arch=$(rpm --eval "%{_arch}")
     local result_dir="${tmp_dir}/mock/${package}"
-    local srpm_prefix="${package}${version:+-$version}"
 
     mkdir -p "${result_dir}"
-    mock -r ssm-9-${arch} -n --resultdir ${result_dir} --rebuild ${srpm_dir}/${srpm_prefix}*.src.rpm
+    rm -f "${result_dir}/${package}*.rpm"
+    mock -r ssm-9-${arch} -n --resultdir ${result_dir} --rebuild "${srpm_filepath}"
+    rm -f "${rpm_dir}/${package}*.rpm"
     mv ${result_dir}/${package}*.${arch}.rpm ${rpm_dir}/
 }
 
 create_rpm() {
     local package=$1
-    local version=
 
-    mkdir -p ${srpm_dir} ${rpm_dir}
+    mkdir -p ${srpm_dir} ${rpm_dir} ${record_dir}
 
-    #TODO: Arange a blackboard file to pass in the correct srpm filenames
-    srpm_filename=$(ls ${srpm_dir}/${package}*.src.rpm | tail -1)
-    if [ -z "${srpm_filename}" ]
+    srpm_filepath="$(echo "${srpm_records[${package}]}" | cut -d',' -f1)"
+    if [ -z "${srpm_filepath}" ] || [ ! -f "${srpm_filepath}" ]
     then
-	echo "Failed to find srpm for ${package}. Failing" 1>&2
-	exit -1
+        echo "${package} : Failed to find srpm for ${package}. Failing" 1>&2
+        exit -1
     fi
-    rpm_filename="$(rpmquery "${srpm_filename}").rpm"
 
-    if [ -f "${rpm_dir}/${rpm_filename}" ]; then
-        echo "${rpm_filename} exists, skipped"
+    built_filepaths="$(echo "${rpm_records[${package}]}" | cut -d',' -f1)"
+    built_revision="$(echo "${rpm_records[${package}]}" | cut -d',' -f2)"
+    cd "${submodule_dir}/${package}"
+    if [ -r "${submodule_dir}/${package}/.git" ]
+    then
+        current_revision="$(git rev-parse --short  HEAD)"
+        [ ! -z "$current_revision" ] || fatal "${package} : Can't not get git commit id of ${package}"
+    else
+        [ -f "${package}.spec" ] || fatal "${package} : No spec file found for ${package}"
+        current_revision="$(rpm -q --qf '%{version}-%{release}' --specfile ${package}.spec)"
+    fi
+
+    all_exist=0
+    for path in ${built_filepaths//:/ }
+    do
+        all_exist=1
+        if [ ! -f "$path" ]
+        then
+            all_exist=0
+            break
+        fi
+    done
+    if [ "$built_revision" = "$current_revision" ] && [ "$all_exist" -gt "0" ]
+    then
+        echo "${package}: RPM of revision '$current_revision' already built, skipped."
         return
     fi
 
-    rm -f ${rpm_dir}/${package}*
-    build_rpm $package $version
+    result_dir="${tmp_dir}/mock/${package}"
+    build_rpm "$package" "$srpm_filepath" "$result_dir"
+
+    printf -v rpm_filepaths '%s:' $(ls ${rpm_dir}/${package}*.rpm)
+    rpm_records[$package]="${rpm_filepaths%%:},${current_revision}"
+
+    record_content=
+    for k in "${!rpm_records[@]}"
+    do
+        if [ -z "${record_content}" ]
+		then
+			record_content="${k},${rpm_records[${k}]}"
+		else
+			record_content="${record_content}"$'\n'"${k},${rpm_records[${k}]}"
+		fi
+    done
+    echo "$record_content" > "${rpm_record_file}"
 }
 
 check_commands() {
@@ -89,10 +126,10 @@ main() {
     then
 		for package in "${packages[@]}"
 		do
-			create_rpm "$package" |& tee "${buildlog_dir}/${package}.rpm.log"
+			create_rpm "$package" &> >(tee "${buildlog_dir}/${package}.rpm.log")
 		done
     else
-	    create_rpm $package |& tee "${buildlog_dir}/${package}.rpm.log"
+	    create_rpm $package &> >(tee "${buildlog_dir}/${package}.rpm.log")
     fi
 }
 

--- a/build/bin/build-sdeb
+++ b/build/bin/build-sdeb
@@ -30,6 +30,28 @@ build_sdeb() {
         exit 1
     fi
 
+    cd "${submodule_dir}/${package}"
+    current_revision="$(git rev-parse --short  HEAD)"
+	[ ! -z "$current_revision" ] || fatal "${package} : Can't not get git commit id of ${package}"
+    built_filepaths="$(echo ${sdeb_records[$package]} | cut -d',' -f1)"
+	built_revision="$(echo ${sdeb_records[$package]} | cut -d',' -f2)"
+
+    all_exist=0
+    for path in ${built_filepaths//:/ }
+    do
+        all_exist=1
+        if [ ! -f "$path" ]
+        then
+            all_exist=0
+            break
+        fi
+    done
+    if [ "$built_revision" = "$current_revision" ] && [ "$all_exist" -gt "0" ]
+	then
+		echo "${package}: SDEB of revision '$current_revision' already built, skipped."
+		return
+	fi
+
     build_dir=${tmp_dir}/debbuild/SDEB/${package}-${version}
     build_ssm_client_tarball ${package} ${build_dir}
     cp -r ${submodule_dir}/${package}/debian ${build_dir}
@@ -44,6 +66,22 @@ build_sdeb() {
     rm -rf ${sdeb_dir}/${package}*
     mv ${tmp_dir}/debbuild/SDEB/${package}_${version}*.dsc ${sdeb_dir}
     mv ${tmp_dir}/debbuild/SDEB/${package}_${version}*.tar.gz ${sdeb_dir}
+
+    printf -v sdeb_filepaths '%s:' $(ls ${sdeb_dir}/${package}*)
+    sdeb_records[$package]="${sdeb_filepaths%%:},${current_revision}"
+
+    record_content=
+    for k in "${!sdeb_records[@]}"
+    do
+        if [ -z "${record_content}" ]
+		then
+			record_content="${k},${sdeb_records[${k}]}"
+		else
+			record_content="${record_content}"$'\n'"${k},${sdeb_records[${k}]}"
+		fi
+    done
+    mkdir -p "${record_dir}"
+    echo "$record_content" > "${sdeb_record_file}"
 }
 
 git_url_to_import_path() {

--- a/build/bin/build-srpm
+++ b/build/bin/build-srpm
@@ -80,6 +80,7 @@ function setup()
 
 	mkdir -vp "${buildlog_dir}" || fatal "Error: Failed to create buildlog dir"
 	mkdir -vp "${srpm_dir}" || fatal "Error: Failed to create srpm dir"
+	mkdir -vp "${record_dir}" || fatal "Error: Failed to create record dir"
 
 	#Remove all rpmbuild sources and outputs
 	rm -f "${RPMBUILDROOT}/SOURCES/"*
@@ -322,6 +323,25 @@ function create_srpm()
 {
 	package="${1}"
 
+	built_filepath="$(echo ${srpm_records[$package]} | cut -d',' -f1)"
+	built_revision="$(echo ${srpm_records[$package]} | cut -d',' -f2)"
+
+	cd "${submodule_dir}/${package}"
+	if [ -r "${submodule_dir}/${package}/.git" ]
+	then
+		current_revision="$(git rev-parse --short  HEAD)"
+		[ ! -z "$current_revision" ] || fatal "${package} : Can't not get git commit id of ${package}"
+	else
+		[ -f "${package}.spec" ] || fatal "${package} : No spec file found for ${package}"
+		current_revision="$(rpm -q --qf '%{version}-%{release}' --specfile ${package}.spec)"
+	fi
+
+	if [ "$built_revision" = "$current_revision" ] && [ -f "$built_filepath" ]
+	then
+		trace "${package}: SRPM of revision '$current_revision' already built, skipped."
+		return
+	fi
+
 	(
 		rm -rf ${tmp_dir}/rpmbuild/SRPMS/${package}*
 		rm -rf ${tmp_dir}/rpmbuild/SOURCES/${package}*
@@ -331,6 +351,7 @@ function create_srpm()
 
 		trace "${package} : Building SRPM"
 		rpmbuild -bs --define "debug_package %{nil}" --define "_topdir ${RPMBUILDROOT}" "${RPMBUILDROOT}/SPECS/${package}.spec"
+
 		mv ${tmp_dir}/rpmbuild/SRPMS/${package}*.src.rpm ${srpm_dir}
 	) | tee >(
 		if (grep ': WARN :' > /dev/null)
@@ -347,6 +368,21 @@ function create_srpm()
 			trace "${package} : SRPM FAILED TO BUILD"
 		fi
 	)
+
+	srpm_filepath=$(ls ${srpm_dir}/${package}*.src.rpm | tail -1)
+	srpm_records[$package]="${srpm_filepath},${current_revision}"
+
+	record_content=
+	for k in "${!srpm_records[@]}"
+	do
+		if [ -z "${record_content}" ]
+		then
+			record_content="${k},${srpm_records[${k}]}"
+		else
+			record_content="${record_content}"$'\n'"${k},${srpm_records[${k}]}"
+		fi
+	done
+	echo "$record_content" > "${srpm_record_file}"
 }
 
 ##############################################################################
@@ -378,10 +414,10 @@ function main()
 	if [ "${package}" == "all" ]; then
 		for package in "${packages[@]}"
 		do
-			create_srpm "$package" |& tee "${buildlog_dir}/${package}.log"
+			create_srpm "$package" &> >(tee "${buildlog_dir}/${package}.log")
 		done
 	else
-		create_srpm "$package" |& tee "${buildlog_dir}/${package}.log"
+		create_srpm "$package" &> >(tee "${buildlog_dir}/${package}.log")
 	fi
 
 	trace "$(basename "${0}") : Done"

--- a/build/bin/vars
+++ b/build/bin/vars
@@ -34,6 +34,7 @@ logs_dir=${root_dir}/logs
 docs_dir=${root_dir}/docs
 audit_dir="${result_dir}/audit"
 buildlog_dir="${result_dir}/buildlogs"
+record_dir="${result_dir}/records"
 docbuild_docker_name="${DOCBUILD_DOCKER_NAME:-shatteredsilicon/docbuild}"
 docbuild_docker_tag="${DOCBUILD_DOCKER_TAG:-latest}"
 docbuild_docker_image="${DOCBUILD_DOCKER_IMAGE:-${docbuild_docker_name}:${docbuild_docker_tag}}"
@@ -50,3 +51,47 @@ debbuild_docker_image="${DEBBUILD_DOCKER_IMAGE:-${debbuild_docker_name}:${debbui
 packages=(ssm-qan-app ssm-client percona-toolkit-ssm-minimal ssm-dashboards ssm-manage ssm-managed ssm-server ssm-qan-api rds_exporter snmp_exporter prometheus MariaDB)
 deb_packages=(ssm-client)
 docker_slim_dir=${root_dir}/build/docker-slim
+
+# Read built srpm records.
+# Records are in format "PACKAGE_NAME,FILE_PATH,REVISION"
+declare -A srpm_records
+srpm_record_file="${record_dir}/srpms"
+if [ -r "${srpm_record_file}" ]
+then
+	while IFS=, read -r package filepath revision; do
+		srpm_records["${package}"]="${filepath},${revision}";
+	done < "$srpm_record_file"
+fi
+
+# Read built rpm records
+# Records are in format "PACKAGE_NAME,FILE_PATH[:FILE_PATH],REVISION"
+declare -A rpm_records
+rpm_record_file="${record_dir}/rpms"
+if [ -r "${rpm_record_file}" ]
+then
+	while IFS=, read -r package filepaths revision; do
+		rpm_records["${package}"]="${filepaths},${revision}";
+	done < "$rpm_record_file"
+fi
+
+# Read built sdeb records
+# Records are in format "PACKAGE_NAME,FILE_PATH[:FILE_PATH],REVISION"
+declare -A sdeb_records
+sdeb_record_file="${record_dir}/sdebs"
+if [ -r "${sdeb_record_file}" ]
+then
+	while IFS=, read -r package filepaths revision; do
+		sdeb_records["${package}"]="${filepaths},${revision}";
+	done < "$sdeb_record_file"
+fi
+
+# Read built deb records
+# Records are in format "PACKAGE_NAME,FILE_PATH[:FILE_PATH],REVISION"
+declare -A deb_records
+deb_record_file="${record_dir}/debs"
+if [ -r "${deb_record_file}" ]
+then
+	while IFS=, read -r package filepaths revision; do
+		deb_records["${package}"]="${filepaths},${revision}";
+	done < "$deb_record_file"
+fi


### PR DESCRIPTION
Close #216

This PR is for avoid rebuilding every modules everytime. It adds build record files `./results/records/{srpms,rpms,sdebs,debs}`, records were added one line per package, in format `$package_name,$build_artifact_filepath[:$build_artifact_filepath],$package_revision`. What it does:

- Before building a package, check the record file, see if current revision is built and build artifacts exist, if not, rebuild this package.
    - When building a ssm-* (forked) package, the revision is the git commit id
    - When building a 3rd-party package, the revision is the `%{version}` defined in the `.spec` file.
- After building a package, add/update build record of this package to the record file

Ideally, `make clean` should not be run and build artifacts should not be removed before the SSM build process, but I seem to see some relevant code in https://github.com/shatteredsilicon/ssm-submodules-builder/blob/master/multibuild#L438-L456, but I'm not 100% sure.